### PR TITLE
fix: Rename image-analysis-api to image-insights-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,13 @@ jobs:
           context: .
           load: true
           push: false
-          tags: image-analysis-api:test
+          tags: image-insights-api:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Test Docker image
         run: |
-          docker run -d --name test-container -p 8080:8080 image-analysis-api:test
+          docker run -d --name test-container -p 8080:8080 image-insights-api:test
           sleep 5
           curl -f http://localhost:8080/health || exit 1
           docker stop test-container

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ A lightweight, containerized REST API that analyzes JPEG and PNG images and retu
 
 ```bash
 # Build the image
-docker build -t image-analysis-api .
+docker build -t image-insights-api .
 
 # Run the container
-docker run -p 8080:8080 image-analysis-api
+docker run -p 8080:8080 image-insights-api
 ```
 
 Or use Docker Compose:
@@ -164,7 +164,7 @@ pytest --cov=app --cov-report=html
 ## 📁 Project Structure
 
 ```
-image-analysis-api/
+image-insights-api/
 ├── app/
 │   ├── __init__.py
 │   ├── main.py              # FastAPI application

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 """
-Image Analysis API
+Image Insights API
 
 A stateless REST microservice that provides fast, deterministic image analysis metrics.
 Supports brightness analysis using Rec. 709 perceptual luminance formula.
@@ -23,7 +23,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
-    title="Image Analysis API",
+    title="Image Insights API",
     description="""
 A lightweight, fast, and portable REST API for image analysis.
 
@@ -81,10 +81,10 @@ app.include_router(image_analysis_router)
 @app.get("/", tags=["health"])
 async def root():
     """Health check endpoint."""
-    return {"service": "image-analysis-api", "version": "1.0.0", "status": "healthy"}
+    return {"service": "image-insights-api", "version": "1.0.0", "status": "healthy"}
 
 
 @app.get("/health", tags=["health"])
 async def health_check():
     """Detailed health check endpoint."""
-    return {"status": "healthy", "service": "image-analysis-api", "version": "1.0.0"}
+    return {"status": "healthy", "service": "image-insights-api", "version": "1.0.0"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.8"
 
 services:
-  image-analysis-api:
+  image-insights-api:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: image-analysis-api
+    container_name: image-insights-api
     ports:
       - "8080:8080"
     restart: unless-stopped

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2,8 +2,8 @@
 
 ## 1. Overview
 
-**Product Name:** Image Analysis API
-**Repository:** `image-analysis-api`
+**Product Name:** Image Insights API
+**Repository:** `image-insights-api`
 **Type:** Stateless REST microservice
 **Deployment:** Docker / OCI-compatible runtime
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
-name = "image-analysis-api"
+name = "image-insights-api"
 version = "1.0.0"
 description = "A lightweight REST API for image brightness analysis"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
-    {name = "Image Analysis API Team"}
+    {name = "Image Insights API Team"}
 ]
 keywords = ["image", "analysis", "brightness", "api", "fastapi"]
 classifiers = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ class TestHealthEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
-        assert data["service"] == "image-analysis-api"
+        assert data["service"] == "image-insights-api"
 
     def test_health_endpoint(self, client):
         """Test health check endpoint."""


### PR DESCRIPTION
## Summary

Renames `image-analysis-api` to `image-insights-api` throughout the project to match the repository name.

## Changes

| File | Change |
|------|--------|
| `app/main.py` | Updated FastAPI title and service name in health endpoints |
| `docker-compose.yml` | Updated service and container names |
| `.github/workflows/ci.yml` | Updated Docker image tags |
| `pyproject.toml` | Updated package name and team name |
| `README.md` | Updated Docker commands and project structure |
| `docs/PRD.md` | Updated product and repository names |
| `tests/test_api.py` | Updated service name assertion |

## Testing

All 40 tests pass with the updated service name.