### PR TITLE
fix(ci): Add write permission for creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:


### PR DESCRIPTION
## Summary

Fixes the release workflow failing to create GitHub releases with error:
```
Resource not accessible by integration
```

## Change

Changed `contents` permission from `read` to `write` in the release workflow to allow `softprops/action-gh-release` to create releases.

## After Merging

Once merged, re-run the release workflow or create a new tag (e.g., `v1.0.1`) to trigger a successful release.