### PR TITLE
docs: Add deployment instructions and GHCR image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)
+![GHCR](https://img.shields.io/badge/ghcr.io-image--insights--api-blue?logo=github&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/FastAPI-Framework-009688?logo=fastapi&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&logoColor=white)
 
@@ -17,20 +18,32 @@ A lightweight, containerized REST API that analyzes JPEG and PNG images and retu
 
 ## 🚀 Quick Start
 
-### Using Docker (Recommended)
+### Using Pre-built Docker Image (Recommended)
+
+Pull and run the image from GitHub Container Registry:
 
 ```bash
-# Build the image
-docker build -t image-insights-api .
+# Pull the latest image
+docker pull ghcr.io/hossain-khan/image-insights-api:latest
 
 # Run the container
-docker run -p 8080:8080 image-insights-api
+docker run -p 8080:8080 ghcr.io/hossain-khan/image-insights-api:latest
 ```
 
 Or use Docker Compose:
 
 ```bash
-docker compose up --build
+docker compose up -d
+```
+
+### Building from Source
+
+```bash
+# Build the image locally
+docker build -t image-insights-api .
+
+# Run the container
+docker run -p 8080:8080 image-insights-api
 ```
 
 ### Local Development
@@ -195,14 +208,45 @@ image-insights-api/
 
 ## 🌐 Deployment
 
+### Docker Compose (Easiest)
+
+The included `docker-compose.yml` is ready for production deployment:
+
+```bash
+# Start the service
+docker compose up -d
+
+# View logs
+docker compose logs -f image-insights-api
+
+# Stop the service
+docker compose down
+
+# Update to latest version
+docker compose pull && docker compose up -d
+```
+
+### Container Platforms
+
 The API is stateless and can be deployed to:
 
 - AWS ECS / Fargate
 - Google Cloud Run
 - Azure Container Apps
 - Kubernetes
+- Oracle Cloud Container Instances
 - Fly.io
 - Any Docker-compatible platform
+
+### Docker Image
+
+Available from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/hossain-khan/image-insights-api:latest
+```
+
+**Supported platforms:** `linux/amd64`, `linux/arm64`
 
 ### Health Check
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,98 @@
+# =============================================================================
+# Image Insights API - Docker Compose Configuration
+# =============================================================================
+# A lightweight REST API for image brightness analysis using Rec. 709 luminance.
+#
+# Repository: https://github.com/hossain-khan/image-insights-api
+# Documentation: https://github.com/hossain-khan/image-insights-api/blob/main/docs/API_DOC.md
+# Docker Image: https://github.com/hossain-khan/image-insights-api/pkgs/container/image-insights-api
+#
+# Quick Start:
+#   docker compose up -d
+#
+# Test the API:
+#   curl -X POST http://localhost:8080/v1/image/analysis -F "image=@photo.jpg"
+#
+# API Documentation (when running):
+#   http://localhost:8080/docs
+# =============================================================================
+
 version: "3.8"
 
 services:
+  # ---------------------------------------------------------------------------
+  # Production deployment using pre-built image from GitHub Container Registry
+  # ---------------------------------------------------------------------------
   image-insights-api:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/hossain-khan/image-insights-api:latest
     container_name: image-insights-api
     ports:
       - "8080:8080"
+    environment:
+      - LOG_LEVEL=info
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 10s
     deploy:
       resources:
         limits:
           memory: 512M
+          cpus: "0.5"
         reservations:
           memory: 128M
+          cpus: "0.1"
+
+  # ---------------------------------------------------------------------------
+  # Local development - build from source (uncomment to use)
+  # ---------------------------------------------------------------------------
+  # image-insights-api-dev:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #   container_name: image-insights-api-dev
+  #   ports:
+  #     - "8080:8080"
+  #   restart: unless-stopped
+  #   healthcheck:
+  #     test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 3
+  #     start_period: 5s
+
+# =============================================================================
+# Usage:
+# =============================================================================
+#
+# Production (pre-built image):
+#   docker compose up -d
+#
+# Development (build from source):
+#   docker compose up -d --build image-insights-api-dev
+#
+# View logs:
+#   docker compose logs -f image-insights-api
+#
+# Check status:
+#   docker compose ps
+#
+# Stop:
+#   docker compose down
+#
+# Pull latest and restart:
+#   docker compose pull && docker compose up -d
+#
+# =============================================================================
+# API Endpoints:
+# =============================================================================
+#
+# POST /v1/image/analysis    - Analyze image brightness (metrics: brightness, median, histogram)
+# GET  /health               - Health check
+# GET  /health/ready         - Readiness check
+# GET  /docs                 - Interactive API documentation (Swagger UI)
+#
+# =============================================================================


### PR DESCRIPTION
## Summary

Updates documentation to make it easier for users to deploy the Image Insights API using the pre-built Docker image from GitHub Container Registry.

## Changes

### docker-compose.yml
- Updated to use pre-built image from `ghcr.io/hossain-khan/image-insights-api:latest`
- Added comprehensive header documentation with links to:
  - Repository: https://github.com/hossain-khan/image-insights-api
  - Documentation: https://github.com/hossain-khan/image-insights-api/blob/main/docs/API_DOC.md
  - Docker Image: https://github.com/hossain-khan/image-insights-api/pkgs/container/image-insights-api
- Added commented-out local development configuration option
- Added usage examples and API endpoint reference in comments
- Updated health check to use curl

### README.md
- Added GHCR badge
- Updated Quick Start section with instructions to pull from GHCR
- Expanded Deployment section with:
  - Docker Compose commands (start, logs, stop, update)
  - Container platform options (added Oracle Cloud)
  - Docker image pull instructions
  - Supported platforms (linux/amd64, linux/arm64)

## Deploy with One Command

```bash
docker compose up -d
```

## Test

```bash
curl -X POST http://localhost:8080/v1/image/analysis -F "image=@photo.jpg"
```