### PR TITLE
chore(release): v1.1.0 - Centralize version management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,17 +75,51 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/).
 | **MINOR** | New features, backward-compatible additions | `1.0.0` → `1.1.0` |
 | **PATCH** | Bug fixes, documentation, backward-compatible fixes | `1.0.0` → `1.0.1` |
 
-### Release Process
+### Centralized Version Management
 
-1. **Create a release tag** following semantic versioning:
+The version is managed in a single location:
+
+**File**: `app/__version__.py`
+```python
+"""Version information for Image Insights API."""
+
+__version__ = "1.1.0"
+```
+
+This version is automatically used in:
+- FastAPI documentation (OpenAPI spec)
+- Health check endpoints (`GET /` and `GET /health`)
+- Docker image tags (via GitHub Actions release workflow)
+
+**To update the version:**
+
+1. Edit `app/__version__.py` and update `__version__`:
    ```bash
-   git tag -a v1.2.0 -m "Release v1.2.0 - Description of changes"
-   git push origin v1.2.0
+   # Example: bumping from 1.0.0 to 1.1.0
+   echo '__version__ = "1.1.0"' > app/__version__.py
    ```
 
-2. **GitHub Actions will automatically**:
+2. Commit the change:
+   ```bash
+   git add app/__version__.py
+   git commit -m "chore: bump version to 1.1.0"
+   ```
+
+3. Create and push the release tag (see Release Process below)
+
+### Release Process
+
+1. **Update version** in `app/__version__.py` (if not already done)
+
+2. **Create a release tag** following semantic versioning:
+   ```bash
+   git tag -a v1.1.0 -m "Release v1.1.0 - Add detailed logging with toggle"
+   git push origin v1.1.0
+   ```
+
+3. **GitHub Actions will automatically**:
    - Build multi-platform Docker images (amd64, arm64)
-   - Push to GitHub Container Registry (`ghcr.io/hossain-khan/image-insights-api`)
+   - Push to GitHub Container Registry (`ghcr.io/hossain-khan/image-insights-api:1.1.0`)
    - Create a GitHub Release with auto-generated changelog
 
 ### Version Examples

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 """App package exports."""
 
+from app.__version__ import __version__
 from app.main import app
 
-__all__ = ["app"]
+__all__ = ["__version__", "app"]

--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,0 +1,3 @@
+"""Version information for Image Insights API."""
+
+__version__ = "1.1.0"

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+from app.__version__ import __version__
 from app.api import image_analysis_router
 
 # Configure logging
@@ -56,7 +57,7 @@ Brightness scores range from 0 (black) to 100 (white).
 - Supported formats: JPEG, PNG
 - Processing timeout: 2 seconds
 """,
-    version="1.0.0",
+    version=__version__,
     lifespan=lifespan,
     docs_url="/docs",
     redoc_url="/redoc",
@@ -88,10 +89,10 @@ app.include_router(image_analysis_router)
 @app.get("/", tags=["health"])
 async def root():
     """Health check endpoint."""
-    return {"service": "image-insights-api", "version": "1.0.0", "status": "healthy"}
+    return {"service": "image-insights-api", "version": __version__, "status": "healthy"}
 
 
 @app.get("/health", tags=["health"])
 async def health_check():
     """Detailed health check endpoint."""
-    return {"status": "healthy", "service": "image-insights-api", "version": "1.0.0"}
+    return {"status": "healthy", "service": "image-insights-api", "version": __version__}


### PR DESCRIPTION
## Release v1.1.0

This release centralizes version management and prepares the project for versioned releases.

### Changes

- **Version Management**: Create `app/__version__.py` as single source of truth for version
  - Version is now defined in one place and imported by `app/main.py`
  - Automatically used in OpenAPI spec, health endpoints, and Docker releases
  
- **Updated Imports**: 
  - `app/main.py` now imports `__version__` from `app.__version__`
  - FastAPI version parameter uses centralized `__version__`
  - Health endpoints (`GET /` and `GET /health`) return centralized version
  
- **Documentation**:
  - Updated `.github/copilot-instructions.md` with detailed version management instructions
  - Added instructions for bumping version and creating releases
  - Documented release process and version examples

### Release Notes

**Features:**
- Centralize version management in `app/__version__.py`
- All version references now point to single source of truth
- Improved release workflow documentation

**Breaking Changes:** None  
**Backward Compatibility:** Fully compatible with v1.0.x

### Testing

- ✅ All 58 tests passing
- ✅ Ruff linting: OK
- ✅ Ruff formatting: OK
- ✅ No changes to API behavior

### Release Checklist

- [x] Version centralized in `app/__version__.py`
- [x] All tests passing
- [x] Code quality checks passing
- [x] Documentation updated
- [ ] Merge this PR
- [ ] Create and push tag: `git tag -a v1.1.0 -m "Release v1.1.0..."`
- [ ] Verify GitHub Actions publishes Docker images