### PR TITLE
docs: update swagger.json version to 1.4.0

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2,8 +2,8 @@
   "swagger": "2.0",
   "info": {
     "title": "Image Insights API",
-    "description": "A lightweight REST API for image brightness analysis using Rec. 709 perceptual luminance.\n\n## Features\n- Brightness scoring (0-100)\n- Median luminance calculation\n- Histogram distribution analysis\n\n## Algorithm\nUses ITU-R BT.709 standard: `L = 0.2126R + 0.7152G + 0.0722B`",
-    "version": "1.0.0",
+    "description": "A lightweight REST API for image brightness analysis using Rec. 709 perceptual luminance.\n\n## Features\n- Brightness scoring (0-100)\n- Median luminance calculation\n- Histogram distribution analysis\n- Processing time metrics\n\n## Algorithm\nUses ITU-R BT.709 standard: `L = 0.2126R + 0.7152G + 0.0722B`",
+    "version": "1.4.0",
     "contact": {
       "name": "Image Insights API Team"
     },


### PR DESCRIPTION
## Update Swagger API Specification Version

### Issue
The OpenAPI/Swagger specification in `docs/swagger.json` still showed version `1.0.0` while the codebase was released as `v1.4.0`.

### Changes
- Updated Swagger JSON version from `1.0.0` to `1.4.0`
- Added "Processing time metrics" to the features list in the spec description
- Ensures the API documentation accurately reflects the current release version

### Why This Matters
- API consumers rely on the Swagger/OpenAPI spec to understand the API version
- Keeping this in sync with the actual release version prevents confusion
- Swagger UI and client generators will now show the correct version

### Related PR
- Part of v1.4.0 release (feature: surface processing_time_ms in responses)