### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/docs/DOCUMENTATION_METADATA.md
+++ b/docs/DOCUMENTATION_METADATA.md
@@ -27,7 +27,7 @@ The auto-generated OpenAPI specification now includes comprehensive metadata:
 
 ### Version
 - Automatically synced from [app/__version__.py](../app/__version__.py)
-- Current version: `1.6.0`
+- Current version: `1.7.0`
 
 ### Tag Descriptions
 Tags are defined with detailed descriptions in [app/main.py](../app/main.py):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-insights-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-insights-api",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@cloudflare/containers": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-insights-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Cloudflare Workers wrapper for Image Insights API container",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
## Version Bump to 1.7.0

Updated version references across all files following semantic versioning.

### Files Updated
- ✅ `app/__version__.py` - Already updated to 1.7.0
- ✅ `package.json` - Updated from 1.6.0 to 1.7.0
- ✅ `package-lock.json` - Regenerated via npm install
- ✅ `docs/DOCUMENTATION_METADATA.md` - Updated version reference
- ✅ `docs/swagger.json` - Already updated to 1.7.0
- ✅ `docs/API_DOC.md` - Already updated to 1.7.0

### Release Steps Completed
- [x] Version bump across all files
- [ ] Merge this PR to main
- [ ] Create git tag `v1.7.0`
- [ ] Push tag (triggers GitHub Actions release workflow)

See [docs/RELEASE_PROCESS.md](docs/RELEASE_PROCESS.md) for complete release documentation.