### PR TITLE
Release v1.7.1 - Privacy fix to suppress httpx URL logging

### DIFF
--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,3 +1,3 @@
 """Version information for Image Insights API."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,9 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 
+# Suppress httpx INFO logs to prevent exposing full URLs (PII/privacy concern)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
 logger = logging.getLogger(__name__)
 
 
@@ -137,7 +140,7 @@ app.include_router(image_analysis_router)
                             "summary": "Healthy API",
                             "value": {
                                 "service": "image-insights-api",
-                                "version": "1.7.0",
+                                "version": "1.7.1",
                                 "status": "healthy",
                             },
                         }
@@ -167,7 +170,7 @@ async def root():
                             "value": {
                                 "status": "healthy",
                                 "service": "image-insights-api",
-                                "version": "1.7.0",
+                                "version": "1.7.1",
                             },
                         }
                     }

--- a/docs/API_DOC.md
+++ b/docs/API_DOC.md
@@ -55,7 +55,7 @@ Root endpoint for basic health check.
 ```json
 {
   "service": "image-insights-api",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "status": "healthy"
 }
 ```
@@ -69,7 +69,7 @@ Detailed health check endpoint.
 {
   "status": "healthy",
   "service": "image-insights-api",
-  "version": "1.7.0"
+  "version": "1.7.1"
 }
 ```
 

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12,7 +12,7 @@
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
     },
-    "version": "1.7.0"
+    "version": "1.7.1"
   },
   "paths": {
     "/v1/image/analysis": {
@@ -366,7 +366,7 @@
                     "summary": "Healthy API",
                     "value": {
                       "service": "image-insights-api",
-                      "version": "1.7.0",
+                      "version": "1.7.1",
                       "status": "healthy"
                     }
                   }
@@ -397,7 +397,7 @@
                     "value": {
                       "status": "healthy",
                       "service": "image-insights-api",
-                      "version": "1.7.0"
+                      "version": "1.7.1"
                     }
                   }
                 }


### PR DESCRIPTION
## 🔐 Privacy Fix Release

### Summary
This patch release addresses a privacy concern where the httpx library was logging full image URLs at INFO level, potentially exposing user PII in production logs.

### Changes

**Privacy Enhancement:**
- ✅ Suppress httpx INFO level logs to prevent exposing full URLs in logs
- ✅ Prevents potential PII exposure from user image URLs  
- ✅ Only httpx WARNING/ERROR logs will appear (for debugging connection issues)
- ✅ Application logs remain unchanged (URL redaction still in place)

**Version Updates:**
- `app/__version__.py`: `1.7.0` → `1.7.1`
- `app/main.py`: Added `logging.getLogger("httpx").setLevel(logging.WARNING)` + version updates
- `docs/API_DOC.md`: Updated version in health check examples
- `docs/swagger.json`: Updated OpenAPI spec version

### Before
```
2026-02-22 13:50:21,268 - httpx - INFO - HTTP Request: GET https://lh3.googleusercontent.com/pw/AP1GczOHDsU....B_mNr1=w400-h300 "HTTP/1.1 200 OK"
```

### After
- httpx HTTP request logs are suppressed (no full URL exposure)
- Application logs like "Image downloaded - Size: 0.02MB" still appear (with redacted URL)
- Only httpx WARNING and ERROR logs will appear (connection issues, timeouts, etc.)

### Testing
- ✅ All 129 tests passing
- ✅ No linting errors
- ✅ Version consistency verified across all files

### Impact
- **Security/Privacy:** Prevents user image URLs from appearing in production logs
- **Debugging:** httpx errors and warnings still logged for troubleshooting
- **Breaking Changes:** None - purely additive log suppression

### Related
- Discovered in production logs at `https://image-insights.gohk.uk/`
- Part of ongoing privacy-first design improvements

---

**Type:** Patch Release (1.7.0 → 1.7.1)  
**Category:** Security/Privacy Enhancement